### PR TITLE
Fix rca.h > average.h file name Sc3 Jakarta 26022016

### DIFF
--- a/libs/ipgp/gui/datamodel/originrecordviewer/originrecordviewer.cpp
+++ b/libs/ipgp/gui/datamodel/originrecordviewer/originrecordviewer.cpp
@@ -42,7 +42,7 @@
 #include <seiscomp3/math/filter/chainfilter.h>
 #include <seiscomp3/math/filter/abs.h>
 #include <seiscomp3/math/filter/const.h>
-#include <seiscomp3/math/filter/rca.h>
+#include <seiscomp3/math/filter/average.h>
 #include <seiscomp3/math/filter/op2filter.h>
 #include <seiscomp3/math/filter/stalta.h>
 #include <seiscomp3/math/filter/seismometers.h>

--- a/libs/ipgp/gui/datamodel/stream/streamwidget.cpp
+++ b/libs/ipgp/gui/datamodel/stream/streamwidget.cpp
@@ -36,7 +36,7 @@
 #include <seiscomp3/math/filter/chainfilter.h>
 #include <seiscomp3/math/filter/abs.h>
 #include <seiscomp3/math/filter/const.h>
-#include <seiscomp3/math/filter/rca.h>
+#include <seiscomp3/math/filter/average.h>
 #include <seiscomp3/math/filter/op2filter.h>
 #include <seiscomp3/math/filter/stalta.h>
 #include <seiscomp3/math/filter/seismometers.h>


### PR DESCRIPTION
In seiscomp3 main source, a  file name has changed:

>  "5.0.1"   0x050001
> - Renamed seiscomp3/math/filtering/rca.h to seiscomp3/math/filtering/average.h
>   and made it a "real" average instead of an average of absolute values

https://github.com/SeisComP3/seiscomp3/commit/5080bc117a3089c250eb8800f34e7ab573283e2e
