### PR TITLE
Tiles without extension

### DIFF
--- a/libs/ipgp/gui/map/tile.cpp
+++ b/libs/ipgp/gui/map/tile.cpp
@@ -96,10 +96,13 @@ const int& Tile::z() const {
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 const QString Tile::path() const {
 
+	const QString noext = _path + suffix();
 	const QString png = _path + suffix() + ".png";
 	const QString jpg = _path + suffix() + ".jpg";
 
-	if ( QFile::exists(png) )
+	if ( QFile::exists(noext) )
+		return noext;
+	else if ( QFile::exists(png) )
 		return png;
 	else
 		return jpg;


### PR DESCRIPTION
The mapprojection package stores tiles without extension. This change allow to use these tiles in the ipgp gui's.

The same pull request is pending on the OVSM side.